### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+  statuses: write
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/bug-ops/vkteams-bot/security/code-scanning/4](https://github.com/bug-ops/vkteams-bot/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's steps:
1. The `actions/checkout@v3` step requires `contents: read` to fetch the repository code.
2. The `codecov/codecov-action@v4.0.1` step may require `contents: read` and `statuses: write` to upload coverage reports and update commit statuses.

We will set these permissions explicitly to ensure the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
